### PR TITLE
Fix android 64 bit support

### DIFF
--- a/plugin/src/android/anyline.gradle
+++ b/plugin/src/android/anyline.gradle
@@ -18,7 +18,7 @@ android {
 
   defaultConfig {
       ndk {
-      abiFilters "armeabi-v7a", "x86", "arm64-v8a"
+      abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
     } 
   }
 


### PR DESCRIPTION
Android 64 support was added in version 13 and removed again in this commit: 
https://github.com/Anyline/anyline-ocr-cordova-module/commit/dd53f1831e1b5b2f37ad04a6cb12277bbaaa96b9