### PR TITLE
ios: Enabling Wrapper Information Monitoring

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -24,6 +24,10 @@
             <string>Allow Anyline to access your camera?</string>
         </config-file>
 
+        <config-file target="*-Info.plist" parent="AnylineCordovaPluginVersion">
+            <string>51.3.1</string>
+        </config-file>
+
         <!-- Anyline SDK Cordova Plugin Source for iOS -->
         <header-file src="src/ios/AnylineSDKPlugin.h"/>
         <source-file src="src/ios/AnylineSDKPlugin.m"/>

--- a/plugin/src/ios/AnylineSDKPlugin.m
+++ b/plugin/src/ios/AnylineSDKPlugin.m
@@ -90,7 +90,9 @@
             }
         }
 
-        [AnylineSDK setupWithLicenseKey:licenseKey cacheConfig:cacheConfig error:&error];
+        NSString *version = [NSBundle mainBundle].infoDictionary[@"AnylineCordovaPluginVersion"] ?: @"0.0.0";
+        [AnylineSDK setupWithLicenseKey:licenseKey cacheConfig:cacheConfig wrapperConfig:[ALWrapperConfig cordova:version] error:&error];
+
         if (error) {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                              messageAsString:error.localizedDescription];


### PR DESCRIPTION
Fix 
No known class method for selector 'setupWithLicenseKey:cacheConfig:error:'

https://documentation.anyline.com/ios-sdk-component/latest/wrapper-information-monitoring.html