### PR TITLE
fix(ios): fall back to "App" project folder for cordova-ios 8+

### DIFF
--- a/plugin/scripts/ios/helper.js
+++ b/plugin/scripts/ios/helper.js
@@ -17,11 +17,24 @@ module.exports = {
     },
 
     getXcodeProjectPath: function () {
-        return path.join("platforms", "ios", utilities.getAppName() + ".xcodeproj", "project.pbxproj");
+        var configNamePath = path.join("platforms", "ios", utilities.getAppName() + ".xcodeproj", "project.pbxproj");
+        if (fs.existsSync(configNamePath)) {
+            return configNamePath;
+        }
+
+        // Since cordova-ios 8.0.0 the generated Xcode project/target is always named "App",
+        // regardless of the <name> set in config.xml. Fall back to that when the
+        // config-name path doesn't exist.
+        return path.join("platforms", "ios", "App.xcodeproj", "project.pbxproj");
     },
 
     getShellScriptBuildPhasePath: function () {
-        return path.join("platforms", "ios", utilities.getAppName(), "remove-unneeded-assets.sh");
+        var configNamePath = path.join("platforms", "ios", utilities.getAppName());
+        if (fs.existsSync(configNamePath)) {
+            return path.join(configNamePath, "remove-unneeded-assets.sh");
+        }
+
+        return path.join("platforms", "ios", "App", "remove-unneeded-assets.sh");
     },
 
     addShellScriptBuildPhase: function (context, xcodeProjectPath) {


### PR DESCRIPTION
## Summary

Since cordova-ios 8.0.0, the generated Xcode project/target is always named `App`, regardless of the `<name>` set in `config.xml`. `getXcodeProjectPath()` and `getShellScriptBuildPhasePath()` in `plugin/scripts/ios/helper.js` both build their paths from the raw config.xml name (`utilities.getAppName()`), so on cordova-ios 8+ projects whose `config.xml` `<name>` isn't `App`, both return a path that doesn't exist:

- `getXcodeProjectPath()` points at a nonexistent `platforms/ios/<config-name>.xcodeproj/project.pbxproj`, causing `xcode.project(...).parseSync()` to throw `ENOENT` during `addShellScriptBuildPhase`/`removeShellScriptBuildPhase`.
- `getShellScriptBuildPhasePath()` points at a nonexistent `platforms/ios/<config-name>/remove-unneeded-assets.sh`, so `fs.copyFileSync()` in `addShellScriptBuildPhase()` throws `ENOENT` before ever reaching the Xcode project code.

This only affects `cordova-ios >= 8.0.0`; the CocoaPods vs. SPM toggle already documented in `plugin.xml` for that same cordova-ios version bump is unrelated and out of scope for this PR.

## Fix

Check whether the config-name path actually exists on disk first, and fall back to the fixed `App` folder name when it doesn't — this keeps working unchanged for `cordova-ios < 8.0` projects where the project folder still matches `config.xml`'s `<name>`.

## Test plan

- Verified on a cordova-ios 8.1.1 project where `config.xml`'s `<name>` differs from `App`: before the fix, both `addShellScriptBuildPhase` and `removeShellScriptBuildPhase` threw `ENOENT`; after the fix, they correctly resolve to `platforms/ios/App/...`.
